### PR TITLE
We need to allow reading of missing documents

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -57,7 +57,7 @@ service cloud.firestore {
       allow get: if isLoggedIn();
 
       match /checkins/{checkinId} {
-        allow get: if isPerson(checkinId) || isPerson(resource.data.checkedInBy);
+        allow get: if isPerson(checkinId) || isPerson(resource.data.checkedInBy) || resource == null;
         allow list: if isServiceAccount();
         allow list, delete: if isAdmin();
       }
@@ -93,7 +93,7 @@ service cloud.firestore {
         allow list: if isServiceAccount() || isLoggedIn();
       }
       match /responses/{responseId=**} {
-        allow read: if isServiceAccount() || isPerson(resource.data.personId);
+        allow read: if isServiceAccount() || isPerson(resource.data.personId) || resource == null;
       }
       match /screens/{screenId=**} {
         allow read, write: if isServiceAccount();


### PR DESCRIPTION
In some cases if we deny the request for a document that does not exist
the app interprets that as a hard error and crashes. The solution is not
the best (it should compare resource name) as it gives away absence of
information, but it's the best we are going to get at 10pm :)